### PR TITLE
Include effects of items in displayed stat values

### DIFF
--- a/src/components/PokemonIllustration.tsx
+++ b/src/components/PokemonIllustration.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+
+import { Pokemon } from '@smogon/calc';
+
+import { TRANSITION } from '../styles';
+import { escapeFilename } from '../util/escapeFilename';
+
+type Props = {
+  flip: boolean;
+  pokemon: Pokemon;
+};
+
+function PokemonIllustration({ flip, pokemon }: Props) {
+  const pokemonName = pokemon.name;
+
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        top: -48,
+        right: 0,
+        bottom: 0,
+        left: 0,
+        backgroundImage: `url(/images/pokemon/${
+          pokemon.isDynamaxed
+            ? escapeFilename(pokemonName)
+            : escapeFilename(pokemonName.replace(/-Gmax$/, ''))
+        }.jpg)`,
+        backgroundRepeat: 'no-repeat',
+        backgroundSize: 'contain',
+        backgroundPosition: 'center',
+        filter: 'opacity(25%)',
+        mixBlendMode: 'multiply',
+        transform: flip
+          ? pokemon.isDynamaxed
+            ? 'scale(2, 2)'
+            : 'scale(1, 1)'
+          : pokemon.isDynamaxed
+          ? 'scale(-2, 2)'
+          : 'scale(-1, 1)',
+        transition: `transform ${TRANSITION}`,
+        zIndex: -1,
+      }}
+    />
+  );
+}
+
+export default PokemonIllustration;

--- a/src/components/PokemonPicker.tsx
+++ b/src/components/PokemonPicker.tsx
@@ -226,6 +226,8 @@ function PokemonPicker({
           <PokemonIllustration flip={index !== 0} pokemon={pokemon} />
           <StatHexagon
             boosts={boosts}
+            item={item}
+            species={pokemon.species}
             onBoostsChange={setBoosts}
             natureFavoredStat={plusStat!}
             natureUnfavoredStat={minusStat!}

--- a/src/components/PokemonPicker.tsx
+++ b/src/components/PokemonPicker.tsx
@@ -18,10 +18,9 @@ import { Autocomplete } from '@material-ui/lab';
 import { ABILITIES, ITEMS, NATURES, Pokemon, SPECIES, StatsTable } from '@smogon/calc';
 import { AbilityName, ItemName, StatName, StatusName } from '@smogon/calc/dist/data/interface';
 
-import { TRANSITION } from '../styles';
-import { escapeFilename } from '../util/escapeFilename';
 import { clonePokemon, GENERATION, getNature, STAT_LABEL } from '../util/misc';
 import ItemPicker from './ItemPicker';
+import PokemonIllustration from './PokemonIllustration';
 import StatHexagon from './StatHexagon';
 import StatusLabel, { STATUS } from './StatusLabel';
 import TypeIcon from './TypeIcon';
@@ -224,35 +223,7 @@ function PokemonPicker({
             position: 'relative',
           }}
         >
-          <div
-            style={{
-              position: 'absolute',
-              top: -48,
-              right: 0,
-              bottom: 0,
-              left: 0,
-              backgroundImage: `url(/images/pokemon/${
-                pokemon.isDynamaxed
-                  ? escapeFilename(pokemonName)
-                  : escapeFilename(pokemonName.replace(/-Gmax$/, ''))
-              }.jpg)`,
-              backgroundRepeat: 'no-repeat',
-              backgroundSize: 'contain',
-              backgroundPosition: 'center',
-              filter: 'opacity(25%)',
-              mixBlendMode: 'multiply',
-              transform:
-                index === 0
-                  ? pokemon.isDynamaxed
-                    ? 'scale(-2, 2)'
-                    : 'scale(-1, 1)'
-                  : pokemon.isDynamaxed
-                  ? 'scale(2, 2)'
-                  : 'scale(1, 1)',
-              transition: `transform ${TRANSITION}`,
-              zIndex: -1,
-            }}
-          />
+          <PokemonIllustration flip={index !== 0} pokemon={pokemon} />
           <StatHexagon
             boosts={boosts}
             onBoostsChange={setBoosts}


### PR DESCRIPTION
Include the effects of items, such as Eviolite and Iron Ball, in the displayed stat totals.

This change doesn't affect damage calculation, only the displayed stat totals.